### PR TITLE
Minor fixes to existing BSP entries

### DIFF
--- a/mtb-bsp-dependencies-manifest.xml
+++ b/mtb-bsp-dependencies-manifest.xml
@@ -4173,7 +4173,7 @@
           </dependee>
           <dependee>
             <id>trusted-firmware-m</id>
-            <commit>latest-v1.X</commit>
+            <commit>release-v1.3.5</commit>
           </dependee>
           <dependee>
             <id>recipe-make-cat1a</id>
@@ -4206,7 +4206,7 @@
           </dependee>
           <dependee>
             <id>trusted-firmware-m</id>
-            <commit>latest-v1.X</commit>
+            <commit>release-v1.3.5</commit>
           </dependee>
           <dependee>
             <id>recipe-make-cat1a</id>
@@ -4239,7 +4239,7 @@
           </dependee>
           <dependee>
             <id>trusted-firmware-m</id>
-            <commit>latest-v1.X</commit>
+            <commit>release-v1.3.5</commit>
           </dependee>
           <dependee>
             <id>recipe-make-cat1a</id>
@@ -7563,7 +7563,7 @@
           </dependee>
           <dependee>
             <id>mtb-hal-cat1</id>
-            <commit>latest-v2.X</commit>
+            <commit>release-v2.1.0</commit>
           </dependee>
           <dependee>
             <id>mtb-pdl-cat1</id>
@@ -7588,7 +7588,7 @@
           </dependee>
           <dependee>
             <id>mtb-hal-cat1</id>
-            <commit>latest-v2.X</commit>
+            <commit>release-v2.1.0</commit>
           </dependee>
           <dependee>
             <id>mtb-pdl-cat1</id>
@@ -7618,7 +7618,7 @@
           </dependee>
           <dependee>
             <id>mtb-hal-cat1</id>
-            <commit>latest-v2.X</commit>
+            <commit>release-v2.1.0</commit>
           </dependee>
           <dependee>
             <id>mtb-pdl-cat1</id>

--- a/mtb-bsp-manifest-fv2.xml
+++ b/mtb-bsp-manifest-fv2.xml
@@ -216,7 +216,7 @@
         <li>Quick Start Guide</li>
         </ul>
       ]]></description>
-    <documentation_url>https://www.cypress.com/documentation/development-kitsboards/cy8ckit-045s</documentation_url>
+    <documentation_url>https://www.infineon.com/cms/en/product/evaluation-boards/cy8ckit-045s/</documentation_url>
     <versions>
       <version tools_min_version="2.4.0" flow_version="1.0,2.0" prov_capabilities_per_version="bsp_gen3">
         <num>Latest 2.X release</num>
@@ -1068,7 +1068,7 @@
     <summary>The KIT_XMC72_EVK, a 272-pin evaluation board is based on the XMC7000 family of devices. XMC7000 MCU is designed for industrial applications. The evaluation board carries a XMC7000D microcontroller, a M.2 interface connector for interfacing radio modules based on AIROC&#8482; Wi-Fi and Bluetooth&#174; combos (currently not supported), SMIF dual header compatible with Digilent Pmod for interfacing HYPERBUS&#8482; memories (currently not supported), and headers compatible with Arduino for interfacing Arduino shields. In addition, the board features an on-board programmer/debugger (KitProg3), a 512-Mbit QSPI NOR flash, CAN FD transceiver, Gigabit Ethernet PHY transceiver with RJ45 connector interface, a micro-B connector for USB device interface, three user LEDs, one potentiometer, and two push buttons. The board supports operating voltages from 3.3 V to 5.0 V for XMC7000D device.</summary>
     <prov_capabilities>arduino bsp_gen4 cat1 cat1c ethernet flash_8384k hal i2c kit_xmc72_evk led low_power mcu_gp memory memory_qspi multi_core nor_flash qspi rtc smart_io spi sram_1024k std_crypto switch uart xmc7000</prov_capabilities>
     <description>               &lt;div class="category"&gt;Kit Features:&lt;/div&gt;&lt;ul&gt;                &lt;li&gt;XMC7200D-E272K8384 8MB Flash 272-pin BGA device&lt;/li&gt;                &lt;li&gt;Programming interface (Arm&#174; Standard JTAG, Cortex Debug + ETM with Arm&#174; ETM Mictor)&lt;/li&gt;                &lt;li&gt;Reset control with manual reset switch and voltage supervision&lt;/li&gt;                &lt;li&gt;Gigabit Ethernet interface&lt;/li&gt;                &lt;li&gt;CAN FD interface&lt;/li&gt;                &lt;li&gt;M.2 interface connector to connect radio modules based on AIROC&#8482; Wi-Fi &amp; Bluetooth&#174; combos (currently not supported)&lt;/li&gt;                &lt;li&gt;512-Mbit external Quad SPI NOR Flash that provides a fast, expandable memory for data and code&lt;/li&gt;                &lt;li&gt;KitProg3 on-board SWD programmer/debugger, USB-UART and USB-I2C bridge functionality&lt;/li&gt;                &lt;li&gt;A micro-B connector for USB device interface&lt;/li&gt;                &lt;li&gt;Selectable input supply voltages of 3.3 V and 5.0 V for the XMC7000D device&lt;/li&gt;                &lt;li&gt;Three user LEDs, two user buttons, and a reset button for the XMC7000D device&lt;/li&gt;                &lt;li&gt;A potentiometer which can be used to simulate analog sensor output&lt;/li&gt;                &lt;li&gt;A mode button and a mode LED for KitProg3&lt;/li&gt;                &lt;/ul&gt;&lt;p/&gt;                &lt;div class="category"&gt;Kit Contents:&lt;/div&gt;&lt;ul&gt;                &lt;li&gt;XMC7200 evaluation board&lt;/li&gt;                &lt;li&gt;USB Type-A to Micro-B cable&lt;/li&gt;                &lt;li&gt;12V/3A DC power adapter with additional blades&lt;/li&gt;                &lt;li&gt;Six jumper wires&lt;/li&gt;                &lt;li&gt;Quick start guide&lt;/li&gt;                &lt;/ul&gt;</description>
-    <documentation_url>https://www.infineon.com/KIT_XMC72_EVK</documentation_url>
+    <documentation_url>https://www.infineon.com/cms/en/product/evaluation-boards/KIT_XMC72_EVK</documentation_url>
     <versions>
       <version tools_min_version="3.0.0" flow_version="2.0" prov_capabilities_per_version="">
         <num>Latest 1.X release</num>
@@ -1485,7 +1485,7 @@
         <li>Quick Start Guide</li>
         </ul>
       ]]></description>
-    <documentation_url>https://www.cypress.com/documentation/development-kitsboards/psoc-64-ble-prototyping-kit-cy8cproto-064b0s1-ble</documentation_url>
+    <documentation_url>https://www.infineon.com/cms/en/product/evaluation-boards/cy8cproto-064b0s1-ble/</documentation_url>
     <versions>
       <version tools_min_version="2.4.0" flow_version="1.0,2.0" prov_capabilities_per_version="bsp_gen3">
         <num>Latest 3.X release</num>
@@ -1730,7 +1730,7 @@
         <li>Adafruit 128 x 32 OLED Screen FeatherWing (Adafruit product ID: 2900)</li>
         </ul>
       ]]></description>
-    <documentation_url>http://www.cypress.com/CYSBSYSKIT-01</documentation_url>
+    <documentation_url>https://www.infineon.com/cms/en/product/evaluation-boards/CYSBSYSKIT-01</documentation_url>
     <versions>
       <version tools_min_version="2.4.0" flow_version="2.0" prov_capabilities_per_version="bsp_gen3">
         <num>Latest 3.X release</num>
@@ -1802,7 +1802,7 @@
         <li>Adafruit 128 x 32 OLED Screen FeatherWing (Adafruit product ID: 2900)</li>
         </ul>
       ]]></description>
-    <documentation_url>http://www.cypress.com/CYSBSYSKIT-DEV-01</documentation_url>
+    <documentation_url>https://www.infineon.com/cms/en/product/evaluation-boards/CYSBSYSKIT-DEV-01</documentation_url>
     <versions>
       <version tools_min_version="2.4.0" flow_version="1.0,2.0" prov_capabilities_per_version="bsp_gen3">
         <num>Latest 3.X release</num>

--- a/mtb-bsp-manifest-fv2.xml
+++ b/mtb-bsp-manifest-fv2.xml
@@ -2283,7 +2283,7 @@
     </chips>
     <name>WLC1115-68LQXQ</name>
     <summary>BSP for WLC1 15W Solution</summary>
-    <prov_capabilities>j2 led mcu_gp psoc4 usbpd</prov_capabilities>
+    <prov_capabilities>j2 led mcu_gp psoc4 usbpd wlc1</prov_capabilities>
     <description/>
     <documentation_url>https://www.infineon.com/cms/en/product/evaluation-boards/refwlctx15wc1</documentation_url>
     <versions>

--- a/mtb-bsp-manifest.xml
+++ b/mtb-bsp-manifest.xml
@@ -8,7 +8,7 @@
     </chips>
     <name>CY8CKIT-062-BLE</name>
     <summary>The PSoC&#8482; 6 BLE Pioneer Kit is a low-cost hardware platform that enables design and debug of the PSoC&#8482; 63 Line (CY8C6347BZI-BLD53).</summary>
-    <prov_capabilities>adc arduino ble capsense capsense_button capsense_linear_slider cat1 comp csd cy8ckit_062_ble dac dma flash_1024k fram hal i2c i2s j2 led low_power lptimer mcu_gp memory memory_qspi multi_core nor_flash opamp pdm psoc6 qspi rgb_led rtc smart_io spi sram_288k std_crypto switch uart udb</prov_capabilities>
+    <prov_capabilities>adc arduino capsense capsense_button capsense_linear_slider cat1 cat1a comp csd cy8ckit_062_ble dac dma flash_1024k fram hal i2c i2s j2 led low_power lptimer mcu_gp memory memory_qspi multi_core nor_flash opamp pdm psoc6 qspi rgb_led rtc smart_io spi sram_288k std_crypto switch uart udb</prov_capabilities>
     <description><![CDATA[
         <div class="category">Kit Features:</div><ul>
         <li>BLE v5.0</li>
@@ -25,31 +25,31 @@
       ]]></description>
     <documentation_url>http://www.cypress.com/documentation/development-kitsboards/psoc-6-ble-pioneer-kit</documentation_url>
     <versions>
-      <version flow_version="1.0" prov_capabilities_per_version="bsp_gen1">
+      <version flow_version="1.0" prov_capabilities_per_version="bsp_gen1 ble">
         <num>Latest 1.X release</num>
         <commit>latest-v1.X</commit>
       </version>
-      <version flow_version="1.0" prov_capabilities_per_version="bsp_gen1">
+      <version flow_version="1.0" prov_capabilities_per_version="bsp_gen1 ble">
         <num>1.3.0 release</num>
         <commit>release-v1.3.0</commit>
       </version>
-      <version flow_version="1.0" prov_capabilities_per_version="bsp_gen1">
+      <version flow_version="1.0" prov_capabilities_per_version="bsp_gen1 ble">
         <num>1.2.1 release</num>
         <commit>release-v1.2.1</commit>
       </version>
-      <version flow_version="1.0" prov_capabilities_per_version="bsp_gen1">
+      <version flow_version="1.0" prov_capabilities_per_version="bsp_gen1 ble">
         <num>1.2.0 release</num>
         <commit>release-v1.2.0</commit>
       </version>
-      <version flow_version="1.0" prov_capabilities_per_version="bsp_gen1">
+      <version flow_version="1.0" prov_capabilities_per_version="bsp_gen1 ble">
         <num>1.1.0 release</num>
         <commit>release-v1.1.0</commit>
       </version>
-      <version flow_version="1.0" prov_capabilities_per_version="bsp_gen1">
+      <version flow_version="1.0" prov_capabilities_per_version="bsp_gen1 ble">
         <num>1.0.1 release</num>
         <commit>release-v1.0.1</commit>
       </version>
-      <version flow_version="1.0" prov_capabilities_per_version="bsp_gen1">
+      <version flow_version="1.0" prov_capabilities_per_version="bsp_gen1 ble">
         <num>1.0.0 release</num>
         <commit>release-v1.0.0</commit>
       </version>
@@ -65,7 +65,7 @@
     </chips>
     <name>CY8CKIT-062S2-43012</name>
     <summary>The CY8CKIT-062S2-43012 PSoC&#8482; 6S2 Wi-Fi BT Pioneer Kit is a low-cost hardware platform that enables design and debug of PSoC&#8482; 6 MCUs. It comes with a Murata 1LV Module (CYW43012 Wi-Fi + Bluetooth Combo Chip), industry-leading CAPSENSE&#8482; for touch buttons and slider, on-board debugger/programmer with KitProg3, microSD card interface, 512-Mb Quad-SPI NOR flash, PDM-PCM microphone interface.</summary>
-    <prov_capabilities>adc anycloud arduino bt capsense capsense_button capsense_linear_slider cat1 comp csd cy8ckit_062s2_43012 cyw43012 cyw43xxx dma flash_2048k fram hal i2c i2s j2 led low_power lptimer mcu_gp memory memory_qspi multi_core nor_flash pdm pot psoc6 qspi rgb_led rtc sdhc smart_io spi sram_1024k std_crypto switch uart usb_device usb_host wifi</prov_capabilities>
+    <prov_capabilities>adc anycloud arduino bt capsense capsense_button capsense_linear_slider cat1 cat1a comp csd cy8ckit_062s2_43012 cyw43012 cyw43xxx dma flash_2048k fram hal i2c i2s j2 led low_power lptimer mcu_gp memory memory_qspi multi_core nor_flash pdm pot psoc6 qspi rgb_led rtc sdhc smart_io spi sram_1024k std_crypto switch uart usb_device usb_host wifi</prov_capabilities>
     <description><![CDATA[
         <div class="category">Kit Features:</div>
         <ul>
@@ -126,7 +126,7 @@
     </chips>
     <name>CY8CKIT-062-WIFI-BT</name>
     <summary>The PSoC&#8482; 6 WiFi-BT Pioneer Kit is a low-cost hardware platform that enables design and debug of the PSoC&#8482; 62 MCU (CY8C6247BZI-D54) and the Murata LBEE5KL1DX Module (CYW4343W WiFi + Bluetooth Combo Chip).</summary>
-    <prov_capabilities>adc anycloud arduino bt capsense capsense_button capsense_linear_slider cat1 comp csd cy8ckit_062_wifi_bt cyw4343w cyw43xxx dac dma flash_1024k fram hal i2c i2s j2 led low_power lptimer mcu_gp memory memory_qspi multi_core nor_flash opamp pdm psoc6 qspi rgb_led rtc smart_io spi sram_288k std_crypto switch uart udb usb_device usb_host wifi</prov_capabilities>
+    <prov_capabilities>adc anycloud arduino bt capsense capsense_button capsense_linear_slider cat1 cat1a comp csd cy8ckit_062_wifi_bt cyw4343w cyw43xxx dac dma flash_1024k fram hal i2c i2s j2 led low_power lptimer mcu_gp memory memory_qspi multi_core nor_flash opamp pdm psoc6 qspi rgb_led rtc smart_io spi sram_288k std_crypto switch uart udb usb_device usb_host wifi</prov_capabilities>
     <description><![CDATA[
         <div class="category">Kit Features:</div><ul>
         <li>BLE v5.0</li>
@@ -185,7 +185,7 @@
     </chips>
     <name>CY8CKIT-064B0S2-4343W</name>
     <summary>The CY8CKIT-064B0S2-4343W PSoC&#8482; 64 Secure Boot Wi-Fi BT Pioneer Kit is a low-cost hardware platform that enables design and debug of PSoC&#8482; 64 MCUs. It comes with a Murata LBEE5KL1DX Module (CYW4343W Wi-Fi + Bluetooth Combo Chip), industry-leading CAPSENSE&#8482; for touch buttons and slider, on-board debugger/programmer with KitProg3, microSD card interface, 512-Mb Quad-SPI NOR flash, 4-MBit Quad-SPI F-RAM, and a PDM-PCM microphone interface.</summary>
-    <prov_capabilities>adc arduino bt capsense capsense_button capsense_linear_slider cat1 comp csd cy8ckit_064b0s2_4343w cyw4343w cyw43xxx dma fram flash_1856k hal i2c i2s j2 led low_power lptimer mcu_gp memory memory_qspi nor_flash pdm pot psoc6 qspi rgb_led rtc secure_boot smart_io spi sram_1024k std_crypto switch uart usb_device usb_host wifi</prov_capabilities>
+    <prov_capabilities>adc arduino bt capsense capsense_button capsense_linear_slider cat1 cat1a comp csd cy8ckit_064b0s2_4343w cyw4343w cyw43xxx dma flash_1856k fram hal i2c i2s j2 led low_power lptimer mcu_gp memory memory_qspi nor_flash pdm pot psoc6 qspi rgb_led rtc secure_boot smart_io spi sram_1024k std_crypto switch uart usb_device usb_host wifi</prov_capabilities>
     <description><![CDATA[
         <div class="category">Kit Features:</div>
         <ul>
@@ -226,7 +226,7 @@
     </chips>
     <name>CY8CPROTO-062-4343W</name>
     <summary>The CY8CPROTO-062-4343W PSoC&#8482; 6 Wi-Fi BT Prototyping Kit is a low-cost hardware platform that enables design and debug of PSoC&#8482; 6 MCUs. It comes with a Murata LBEE5KL1DX module, based on the CYW4343W combo device, industry-leading CAPSENSE&#8482; for touch buttons and slider, on-board debugger/programmer with KitProg3, microSD card interface, 512-Mb Quad-SPI NOR flash, PDM-PCM microphone, and a thermistor. This kit is designed with a snap-away form-factor, allowing the user to separate the different components and features that come with this kit and use independently. In addition, support for Digilent's Pmod interface is also provided with this kit.</summary>
-    <prov_capabilities>adc anycloud bt capsense capsense_button capsense_linear_slider cat1 comp csd cy8cproto_062_4343w cyw4343w cyw43xxx dma flash_2048k hal i2c i2s led low_power lptimer mcu_gp memory memory_qspi multi_core nor_flash pdm psoc6 qspi rtc sdhc smart_io spi sram_1024k std_crypto switch uart usb_device wifi</prov_capabilities>
+    <prov_capabilities>adc anycloud bt capsense capsense_button capsense_linear_slider cat1 cat1a comp csd cy8cproto_062_4343w cyw4343w cyw43xxx dma flash_2048k hal i2c i2s led low_power lptimer mcu_gp memory memory_qspi multi_core nor_flash pdm psoc6 qspi rtc sdhc smart_io spi sram_1024k std_crypto switch uart usb_device wifi</prov_capabilities>
     <description><![CDATA[
         <div class="category">Kit Features:</div>
         <ul>
@@ -281,7 +281,7 @@
     </chips>
     <name>CY8CPROTO-062S3-4343W</name>
     <summary>The CY8CPROTO-062S3-4343W Kit is a low-cost hardware platform that enables design and debug of the PSoC&#8482; 6 MCUs.It comes with a Murata LBEE5KL1DX module, based on the CYW4343W combo device, industry-leading CAPSENSE&#8482; for touch buttons and slider, on-board debugger/programmer with KitProg3, 512-Mb Quad-SPI NOR flash. This kit is designed with a snap-away form-factor, allowing the user to separate the different components and features that come with this kit and use independently.</summary>
-    <prov_capabilities>adc bt capsense capsense_button capsense_linear_slider cat1 comp csd cy8cproto_062s3_4343w cyw4343w cyw43xxx dma flash_512k hal i2c led low_power lptimer mcu_gp memory memory_qspi multi_core nor_flash psoc6 qspi rtc smart_io spi sram_256k std_crypto switch uart usb_device wifi</prov_capabilities>
+    <prov_capabilities>adc bt can capsense capsense_button capsense_linear_slider cat1 cat1a comp csd cy8cproto_062s3_4343w cyw4343w cyw43xxx dma flash_512k hal i2c led low_power lptimer mcu_gp memory memory_qspi multi_core nor_flash psoc6 qspi rtc smart_io spi sram_256k std_crypto switch uart usb_device wifi</prov_capabilities>
     <description><![CDATA[
         <div class="category">Kit Features:</div>
         <ul>
@@ -335,7 +335,7 @@
     </chips>
     <name>CY8CPROTO-063-BLE</name>
     <summary>The PSoC&#8482; 6 BLE Prototyping Kit (CY8CPROTO-063-BLE) is a low-cost hardware platform that enables design and debug of PSoC&#8482; 6 MCUs. This kit is designed with a snap-away form-factor, allowing users to separate the KitProg (on-board programmer and debugger) from the target board and use independently.</summary>
-    <prov_capabilities>adc ble capsense cat1 comp csd cy8cproto_063_ble dac dma flash_1024k hal i2c led low_power lptimer mcu_gp multi_core opamp psoc6 qspi rtc smart_io spi sram_288k std_crypto switch uart udb</prov_capabilities>
+    <prov_capabilities>adc capsense cat1 cat1a comp csd cy8cproto_063_ble dac dma flash_1024k hal i2c led low_power lptimer mcu_gp multi_core opamp psoc6 qspi rtc smart_io spi sram_288k std_crypto switch uart udb</prov_capabilities>
     <description><![CDATA[
         <div class="category">Kit Features:</div>
         <ul>
@@ -353,27 +353,27 @@
       ]]></description>
     <documentation_url>http://www.cypress.com/CY8CPROTO-063-BLE</documentation_url>
     <versions>
-      <version flow_version="1.0" prov_capabilities_per_version="bsp_gen1">
+      <version flow_version="1.0" prov_capabilities_per_version="bsp_gen1 ble">
         <num>Latest 1.X release</num>
         <commit>latest-v1.X</commit>
       </version>
-      <version flow_version="1.0" prov_capabilities_per_version="bsp_gen1">
+      <version flow_version="1.0" prov_capabilities_per_version="bsp_gen1 ble">
         <num>1.3.0 release</num>
         <commit>release-v1.3.0</commit>
       </version>
-      <version flow_version="1.0" prov_capabilities_per_version="bsp_gen1">
+      <version flow_version="1.0" prov_capabilities_per_version="bsp_gen1 ble">
         <num>1.2.1 release</num>
         <commit>release-v1.2.1</commit>
       </version>
-      <version flow_version="1.0" prov_capabilities_per_version="bsp_gen1">
+      <version flow_version="1.0" prov_capabilities_per_version="bsp_gen1 ble">
         <num>1.2.0 release</num>
         <commit>release-v1.2.0</commit>
       </version>
-      <version flow_version="1.0" prov_capabilities_per_version="bsp_gen1">
+      <version flow_version="1.0" prov_capabilities_per_version="bsp_gen1 ble">
         <num>1.1.0 release</num>
         <commit>release-v1.1.0</commit>
       </version>
-      <version flow_version="1.0" prov_capabilities_per_version="bsp_gen1">
+      <version flow_version="1.0" prov_capabilities_per_version="bsp_gen1 ble">
         <num>1.0.0 release</num>
         <commit>release-v1.0.0</commit>
       </version>
@@ -388,7 +388,7 @@
     </chips>
     <name>CY8CPROTO-064B0S3</name>
     <summary>CY8CPROTO-064B0S3 PSoC&#8482; 64 Secure Boot Prototyping Kit is a low-cost Prototyping Kit based on PSoC&#8482; 64 Secure Boot MCU to enable customers to prototype and design with the PSoC&#8482; 64 Secure Boot device.</summary>
-    <prov_capabilities>adc cat1 comp cy8cproto_064b0s3 dma flash_448k hal i2c led low_power lptimer mcu_gp memory memory_qspi nor_flash psoc6 qspi rtc secure_boot smart_io spi sram_256k std_crypto uart usb_device</prov_capabilities>
+    <prov_capabilities>adc cat1 cat1a comp cy8cproto_064b0s3 dma flash_448k hal i2c led low_power lptimer mcu_gp memory memory_qspi nor_flash psoc6 qspi rtc secure_boot smart_io spi sram_256k std_crypto uart usb_device</prov_capabilities>
     <description><![CDATA[
         <div class="category">Kit Features:</div><ul>
         <li>PSoC&#8482; 64 Secure MCU</li>
@@ -432,7 +432,7 @@
     </chips>
     <name>CYW9P62S1-43012EVB-01</name>
     <summary>The CYW9P62S1-43012EVB-01 Kit is a low-cost hardware platform that enables design and debug of the USI WM-BAC-CYW-50 Module. USI WM-BAC-CYW-50 is a System in Package (SiP) module that contains the PSoC&#8482; 62 MCU (CY8C6247FDI-D52) and the radio part CYW43012 (WiFi + Bluetooth Combo Chip).</summary>
-    <prov_capabilities>adc anycloud arduino bt capsense capsense_button capsense_linear_slider cat1 comp csd cyw43012 cyw43xxx cyw9p62s1_43012evb_01 dac dma flash_1024k fram hal i2c i2s j2 led low_power lptimer mcu_gp memory memory_qspi multi_core nor_flash opamp pdm psoc6 qspi rtc smart_io spi sram_288k std_crypto switch uart udb usb_device wifi</prov_capabilities>
+    <prov_capabilities>adc anycloud arduino bt capsense capsense_button capsense_linear_slider cat1 cat1a comp csd cyw43012 cyw43xxx cyw9p62s1_43012evb_01 dac dma flash_1024k fram hal i2c i2s j2 led low_power lptimer mcu_gp memory memory_qspi multi_core nor_flash opamp pdm psoc6 qspi rtc smart_io spi sram_288k std_crypto switch uart udb usb_device wifi</prov_capabilities>
     <description><![CDATA[
         <div class="category">Kit Features:</div><ul>
         <li>Support of up to 1MB Flash and 288KB SRAM</li>
@@ -493,7 +493,7 @@
     </chips>
     <name>CYW9P62S1-43438EVB-01</name>
     <summary>The CYW9P62S1-43438EVB-01 Kit is a low-cost hardware platform that enables design and debug of the Azurewave AW-CU427 Module. AW-CU427 is a System in Package (SiP) module that contains the MCU part, PSoC&#8482; 62 MCU (CY8C6247BZI-D54) and the radio part CYW43438 ( WiFi + Bluetooth Combo Chip).</summary>
-    <prov_capabilities>adc anycloud arduino bt capsense capsense_button capsense_linear_slider cat1 comp cyw43438 cyw43xxx cyw9p62s1_43438evb_01 dac dma flash_1024k fram hal i2c i2s j2 led low_power lptimer mcu_gp memory memory_qspi multi_core nor_flash opamp pdm pot psoc6 qspi rgb_led rtc smart_io spi sram_288k std_crypto switch uart udb usb_device usb_host wifi</prov_capabilities>
+    <prov_capabilities>adc anycloud arduino bt capsense capsense_button capsense_linear_slider cat1 cat1a comp csd cyw43438 cyw43xxx cyw9p62s1_43438evb_01 dac dma flash_1024k fram hal i2c i2s j2 led low_power lptimer mcu_gp memory memory_qspi multi_core nor_flash opamp pdm pot psoc6 qspi rgb_led rtc smart_io spi sram_288k std_crypto switch uart udb usb_device usb_host wifi</prov_capabilities>
     <description><![CDATA[
         <div class="category">Kit Features:</div><ul>
         <li>Support of up to 1MB Flash and 288KB SRAM</li>
@@ -545,7 +545,7 @@
     </chips>
     <name>PSOC6-GENERIC</name>
     <summary>This board support package is intended for creating custom PSoC&#8482; 6 BSPs.</summary>
-    <prov_capabilities>cat1 hal low_power mcu_gp psoc6 rtc</prov_capabilities>
+    <prov_capabilities>cat1 cat1a hal low_power mcu_gp psoc6 rtc</prov_capabilities>
     <description><![CDATA[
         <div class="category">Kit Features:</div><ul>
         <li>This is a generic template, there is no corresponding physical board and hence no board-specific macros. The user is expected to create a custom BSP with various pin/hardware details - Refer to KBA230822. Code examples using kit/board resources will not be shown for this BSP until the manifest data for the BSP is updated to include additional capabilities. Refer to ModusToolbox user guide for creating custom manifests.</li>


### PR DESCRIPTION
- Fix documentation URLs
- Lock dependency versions for pre-gen4 BSPs where necessary to maintain compatibility in newer environments.
- Add "wlc1" capability to WLC1115-68LQXQ BSP